### PR TITLE
Fogpyx marzod/sc 2014/Twitter UV: Don't show anything for tweets with 0 thread count

### DIFF
--- a/src/react/Preview.tsx
+++ b/src/react/Preview.tsx
@@ -111,15 +111,20 @@ function Preview({ tweet, threadCount }: PreviewProps) {
           </div>
         </div>
       </div>
-      {/* Logic for only showing on Unroll Thread that contains tweets */}
-      {threadCount && <div className="unroll-thread-count">And {threadCount} more tweets</div>}
+      {threadCount > 0 ? (
+        <div className="unroll-thread-count">
+          And {threadCount} more {threadCount > 1 ? 'tweets' : 'tweet'}{' '}
+        </div>
+      ) : (
+        ''
+      )}
     </div>
   );
 }
 
 function Quote({ quote }) {
   const parsedText = parseText(quote.text);
-  console.log(parsedText, "parsed text")
+  console.log(parsedText, 'parsed text');
 
   return (
     <div id="tweet-quote" className={quote.pics.length > 0 ? 'tweet-contains-pics' : ''}>
@@ -137,10 +142,7 @@ function Quote({ quote }) {
         <div id="tweet-body">
           <div className="tweet-text">
             {parsedText.map((sentence, index) => (
-              <p
-                key={index}
-                className={sentence.length < 1 ? "line-break" : ""}
-              >
+              <p key={index} className={sentence.length < 1 ? 'line-break' : ''}>
                 {sentence}
               </p>
             ))}

--- a/src/react/Preview.tsx
+++ b/src/react/Preview.tsx
@@ -25,7 +25,7 @@ const generateMapKey = () => {
 
 interface PreviewProps {
   tweet: Tweet;
-  threadCount: number;
+  threadCount?: number;
 }
 
 const parseText = (text: String, entities?: TweetEntity[]) => {

--- a/src/react/ShareModal.tsx
+++ b/src/react/ShareModal.tsx
@@ -55,8 +55,8 @@ export default function ShareModal(props: ModalProps) {
       if (leakingMemory) {
         // error handling here, shit happens
         setTweet(tweet);
-        if (props.unrolling) setUnroll(tweet)
-        else setLinkOnly(tweet)
+        if (props.unrolling) setUnroll(tweet);
+        else setLinkOnly(tweet);
         setLoading(false);
       }
     });
@@ -100,19 +100,19 @@ export default function ShareModal(props: ModalProps) {
 
   function setFullTweet(tweet) {
     setChannelFilters(['link']);
-    setPreview(<Preview tweet={tweet.parent}/>);
+    setPreview(<Preview tweet={tweet.parent} />);
     setTitle('Tweet ' + titleFromTweet(tweet.parent));
     setPayload(tweetToGraphStore(tweet.parent));
   }
   function setLinkOnly(tweet) {
     setChannelFilters([]);
-    setPreview(<Preview tweet={tweet.parent}/>);
+    setPreview(<Preview tweet={tweet.parent} />);
     setTitle('Tweet ' + titleFromTweet(tweet.parent));
     setPayload(`[${props.url.href}](${props.url.href})`);
   }
   function setUnroll(tweet) {
     setChannelFilters(['chat', 'link', 'post']);
-    setPreview(<Preview tweet={tweet.parent} threadCount={tweet.children.length} />); // (temporary) note: logic should be like => tweet.hasThreadCount ? fullTweetWithCount : fullTweet
+    setPreview(<Preview tweet={tweet.parent} threadCount={tweet.children.length} />);
     setTitle('Unrolled Thread ' + titleFromTweet(tweet.parent));
     setPayload(threadToGraphStore(tweet));
   }
@@ -158,7 +158,7 @@ export default function ShareModal(props: ModalProps) {
         </div>
         <div className="preview-tab-container">
           <div
-            className={props.unrolling ? "tweet-preview-tab" : "tweet-preview-tab active-tab"}
+            className={props.unrolling ? 'tweet-preview-tab' : 'tweet-preview-tab active-tab'}
             onClick={event => {
               setLinkOnly(tweet);
               applyActiveTab(event);
@@ -170,7 +170,7 @@ export default function ShareModal(props: ModalProps) {
         </div>
         <div className="preview-tab-container">
           <div
-            className={props.unrolling ? "tweet-preview-tab active-tab" : "tweet-preview-tab"}
+            className={props.unrolling ? 'tweet-preview-tab active-tab' : 'tweet-preview-tab'}
             onClick={event => {
               setUnroll(tweet);
               applyActiveTab(event);


### PR DESCRIPTION
Fixes this:
<img width="613" alt="Screen Shot 2022-02-08 at 10 14 55" src="https://user-images.githubusercontent.com/20974577/152899307-eaa6f45a-5cef-4f29-ad69-2087e78fa98c.png">

And makes thread count appear as "And 1 more tweet" instead of "And 1 more tweets"